### PR TITLE
Fixes app stuck in Splash/ black screen issue #875

### DIFF
--- a/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
+++ b/audio_service/android/src/main/java/com/ryanheise/audioservice/AudioService.java
@@ -341,8 +341,13 @@ public class AudioService extends MediaBrowserServiceCompat {
             }
         };
 
-        flutterEngine = AudioServicePlugin.getFlutterEngine(this);
-        System.out.println("flutterEngine warmed up");
+        // NOTE : This is our custom Isha Fork used as a work around for these issues : 
+            // App stuck in black screen or native splash when opened after receiving a push notification :
+            // https://github.com/ryanheise/audio_service/issues/875   
+        // ->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>  SOLUTION : Comment below 2 lines :
+        // flutterEngine = AudioServicePlugin.getFlutterEngine(this);
+        // System.out.println("flutterEngine warmed up");
+        // ->>>>>>>>>>>>>>>>>>>>>>>>>>>>>>  END OF SOLUTION
     }
 
     @Override


### PR DESCRIPTION
Issue details : https://github.com/ryanheise/audio_service/issues/875

We are facing : 
- App stuck in black screen when opening app from push notification.
- App stuck in splash logo when opening app directly from launcher after receiving push notification.

*Replace this paragraph with a description of what this PR is changing or adding, and why.*

*If there's an open issue your PR is fixing, please list it here.*

## Pre-launch Checklist

- [x] I read the [CONTRIBUTING.md] and followed the process outlined there for submitting PRs.
- [x] My change is not breaking and lands in `minor` branch OR my change is breaking and lands in `major` branch.
- [ ] If I'm the first to contribute to the next version, I incremented the version number in `pubspec.yaml` according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change (format: `* DESCRIPTION OF YOUR CHANGE (@your-git-username)`).
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I ran `dart analyze`.
- [ ] I ran `dart format`.
- [ ] I ran `flutter test` and all tests are passing.

<!-- Links -->
[CONTRIBUTING.md]: https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md#making-a-pull-request
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
